### PR TITLE
Fixes issue where pong app lost focus in Firefox

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,7 @@
 function setFocusPongFrame() {
     var iframe = $("#pongFrame")[0];
+
+    // Focus is set after returning to the browser so it works in Firefox
     setTimeout( function() { 
         iframe.contentWindow.focus();
     }, 0);


### PR DESCRIPTION
I believe that the focus was still tied up on the original focus change away from the pong app, and it got all sorts of confused in Firefox when we tried to change it back.  Just letting the code return to the browser fixed it.  :smile: 

@allisoncorey, would you mind reviewing?
