### PR TITLE
Fix broken links

### DIFF
--- a/_includes/docs/introduction.md
+++ b/_includes/docs/introduction.md
@@ -20,7 +20,7 @@ Use the Virtual World Framework (VWF) to create apps that are:
   var chars = [ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' ];
     for ( var i = 0; i < 16; i++ )
       sessionId += chars[ Math.floor( Math.random() * 16 ) ];
-    return "https://virtual.wf/duck/" + sessionId;
+    return "https://demo.virtual.wf/duck/" + sessionId;
   };
 
   this.Url = this.createAppUrl();

--- a/_includes/docs/lights.md
+++ b/_includes/docs/lights.md
@@ -48,11 +48,11 @@ Spot1:
 
 ### Lighting Effects
 
-#### Specular Reflection
+#### Specular
 
-Specular reflection is the reflection of light from a surface where the ray is reflected in a single direction. 
+Specular reflection is the reflection of light from a surface where the ray is reflected in a single direction.
 
-#### Diffuse Reflection
-   
+#### Diffuse
+
 Diffuse reflection is the reflection of light from a surface where the ray is reflected at many angles.
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -132,9 +132,9 @@ You'll notice that we set the value for the color by adding a `properties` secti
 
 The `material.vwf` component uses the `color` property to determine the object's color. If you tried changing the name of the `color` property to `myColor`, you'll notice that the ball is still gray.
 
-`material.vwf` does a whole lot more than just color. It can handle textures, opacity, and even shininess. Check out the [Material Documentation](https://virtual.wf/documentation.html#materials) for a proper rundown.
+`material.vwf` does a whole lot more than just color. It can handle textures, opacity, and even shininess. Check out the [Material Documentation](/documentation.html#materials) for a proper rundown.
 
-For more information on components, properties, and the `extends` keyword, see the [Components Documentation](https://virtual.wf/documentation.html#components).
+For more information on components, properties, and the `extends` keyword, see the [Components Documentation](/documentation.html#components).
 
 ### Lighting Things Up
 
@@ -170,7 +170,7 @@ Once again, we added a few special properties to `light` that `light.vwf` depend
 
 `distance` tells the light how far it's effective range is. Since we're moving ours about 1000 units or so from the board, let's make distance comfortably large, like 2000, to make sure it's lighting all the models in our scene.
 
-Lights default to being point lights, meaning they shine in all directions simultaneously. VWF also supports directional and spot lights, as well as a host of properties for manipulating lighting including color, intensity, and softness. For more information on lighting in VWF, see the [Lighting Documentation](https://virtual.wf/documentation.html#lights).
+Lights default to being point lights, meaning they shine in all directions simultaneously. VWF also supports directional and spot lights, as well as a host of properties for manipulating lighting including color, intensity, and softness. For more information on lighting in VWF, see the [Lighting Documentation](/documentation.html#lights).
 
 ### Positioning the Camera
 
@@ -228,7 +228,7 @@ Give that a reload, and you should have the board centered in your application's
 
 ![](/images/shot4.png)
 
-For more information about manipulating the camera, see the [Camera Documentation](http://virtual.wf/documentation.html#cameras).
+For more information about manipulating the camera, see the [Camera Documentation](/documentation.html#cameras).
 
 ### Position the Paddle
 

--- a/js/index.js
+++ b/js/index.js
@@ -45,7 +45,7 @@ function checkCompatibility() {
             errorHtml += "  <li>WebGL</li>\n";
         }
         errorHtml += "</ul>\n" +
-                     "<p>... and it does not. For a list of compatible browsers, see <a href='https://virtual.wf/documentation.html#requirements'>Browser Requirements</a>. If your browser is listed, you may need to enable the necessary features. Google can help you find how to do that.</p>\n";
+                     "<p>... and it does not. For a list of compatible browsers, see <a href='/documentation.html#requirements'>Browser Requirements</a>. If your browser is listed, you may need to enable the necessary features. Google can help you find how to do that.</p>\n";
         compatibility.errorHtml = errorHtml;
     }
 


### PR DESCRIPTION
@jessmartin mind giving this a looksy?

I changed the titles in the lighting section because inexplicably, the page started rendering w/ the `Diffuse Reflections` section sharing the style of the header.  Removing the second word fixed the problem.

What did I tell you?  Html is _voodoo_.

(or was that ruby.  Whatever.  It's both)
