### PR TITLE
Update mars game link to use http instead of https.

### DIFF
--- a/demos.haml
+++ b/demos.haml
@@ -45,16 +45,16 @@ title: Demos - Virtual World Framework
         %h3 Mars Game (beta)
         %p
           ADL's Mars Game teaches high school students math and computer programming concepts as players operate a brave Mars rover who needs to save the human explorers on their way to Mars.
-        %a.btn.btn-info{role: "button", href: "https://development.virtual.wf/mars-game"} Launch New Session
+        %a.btn.btn-info{role: "button", href: "http://development.virtual.wf/mars-game"} Launch New Session
       .col-sm-4
-        %a{href: "https://development.virtual.wf/mars-game"}
+        %a{href: "http://development.virtual.wf/mars-game"}
           %img.img-responsive.img-rounded.pull-right.hidden-xs{src: "/images/gallery-mars-game.png"}
     .row
       .col-xs-12
         .alert.alert-warning
           %p.small
             %span.glyphicon.glyphicon-warning-sign
-            This app will probably warn of certificate errors because it is self-signed with the wrong name.  No need to fear.  We'll fix it at some point.
+            This app features highly detailed models and may take up to five minutes to load.
 
 / .panel.panel-default.panel-demo
 /   .panel-body


### PR DESCRIPTION
Update mars game link to use http instead of https to avoid clicking through certificates. 
Update warning to notify users it may take up to five minutes to load.
